### PR TITLE
Add Mock `.travis.yml` to prevent false negatives.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: generic
+script: false
+notifications:
+  email: false


### PR DESCRIPTION
TravisCI is reporting failure, but there are no tests.
Prevent this with mock `.travis.yml` file.